### PR TITLE
Allow configuration of different autostart choices (#2)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ dropbox_directory: "{{ dropbox_owner_home }}/.dropbox"
 dropbox_user_directory: "{{ dropbox_owner_home }}/Dropbox"
 dropbox_user_host : "1234567890"
 dropbox_utilities_enabled : yes
+# One of "KDE" or "systemd_user", or left undefined to not autostart dropbox
+dropbox_autostart: KDE
 
 dropbox_apt_repo: ubuntu
 dropbox_apt_release: xenial

--- a/tasks/dropbox.yml
+++ b/tasks/dropbox.yml
@@ -70,7 +70,26 @@
 
 - name: dropbox | Configure KDE to autostart dropboxd
   file: path={{ dropbox_owner_home }}/.kde/Autostart/dropboxd src={{ dropbox_owner_home }}/.dropbox-dist/dropboxd state=link
-  ignore_errors: True
+  when: dropbox_autostart == "KDE"
+
+- block:        # block for SystemD user autostart
+  - name: dropbox | Install SystemD dropboxd service
+    template: src=dropbox.service dest=/etc/systemd/user/dropbox.service
+
+  # Workaround for systemd user services bug in ansible prior to 2.6
+  - name: dropbox | Get uid of {{ dropbox_owner }} for SystemD autostart
+    command: id -u {{ dropbox_owner }}
+    register: dropbox_owner_uid
+    changed_when: false
+
+  - name: dropbox | Configure SystemD to autostart dropboxd
+    systemd: name=dropbox.service user=yes enabled=yes
+    environment:
+      XDG_RUNTIME_DIR: /run/user/{{ dropbox_owner_uid.stdout }}
+    become: true
+    become_user: "{{ dropbox_owner }}"
+    # become_method: machinectl   # replacement for workaround on ansible > 2.6
+  when: dropbox_autostart == "systemd_user"
 
 - name: dropbox | Install dropbox utilities
   apt: pkg={{ item }} state=present update_cache=yes

--- a/templates/dropbox.service
+++ b/templates/dropbox.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Dropbox
+
+[Service]
+ExecStart=/usr/bin/dropbox start -i
+Type=forking
+PIDFile=%h/.dropbox/dropbox.pid
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Make autostart choices configurable, initially supporting the existing KDE and a new SystemD user service autostart option.

Note that unlike the existing code, failure to deploy an autostart choice (eg, if $HOME/.kde/Autostart/ doesn't exist and KDE is chosen) will result in an ansible error.  Should I change the default to be no configured autostart?

Also note that I use a workaround to support Ansible versions older than 2.6.  I'd be happy to drop the workaround if you don't want to support Ansblie versions that old.